### PR TITLE
Adjusted siphon based fluids in space pumping

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/SpacePumpingRecipes.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/SpacePumpingRecipes.java
@@ -43,7 +43,7 @@ public class SpacePumpingRecipes {
         RECIPES.put(Pair.of(5, 3), Materials.SaltWater.getFluid(2800000));
         RECIPES.put(Pair.of(5, 4), Materials.Helium.getGas(1400000));
         RECIPES.put(Pair.of(5, 5), Materials.LiquidOxygen.getGas(896000));
-        RECIPES.put(Pair.of(5, 7), Materials.Argon.getGas(8000));
+        RECIPES.put(Pair.of(5, 7), Materials.Argon.getGas(32000));
         RECIPES.put(Pair.of(5, 9), Materials.Methane.getGas(1792000));
 
         // T6
@@ -68,8 +68,8 @@ public class SpacePumpingRecipes {
 
         if (Loader.isModLoaded("bartworks")) {
             // T5
-            RECIPES.put(Pair.of(5, 6), WerkstoffLoader.Neon.getFluidOrGas(8000));
-            RECIPES.put(Pair.of(5, 8), WerkstoffLoader.Krypton.getFluidOrGas(32000));
+            RECIPES.put(Pair.of(5, 6), WerkstoffLoader.Neon.getFluidOrGas(32000));
+            RECIPES.put(Pair.of(5, 8), WerkstoffLoader.Krypton.getFluidOrGas(8000));
 
             // T6
             RECIPES.put(Pair.of(6, 4), WerkstoffLoader.Xenon.getFluidOrGas(16000));

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/SpacePumpingRecipes.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/SpacePumpingRecipes.java
@@ -41,15 +41,15 @@ public class SpacePumpingRecipes {
         RECIPES.put(Pair.of(5, 1), Materials.CarbonMonoxide.getGas(4480000));
         RECIPES.put(Pair.of(5, 2), Materials.Helium_3.getGas(2800000));
         RECIPES.put(Pair.of(5, 3), Materials.SaltWater.getFluid(2800000));
-        RECIPES.put(Pair.of(5, 4), Materials.Helium.getGas(20000));
-        RECIPES.put(Pair.of(5, 5), Materials.LiquidOxygen.getGas(1500));
-        RECIPES.put(Pair.of(5, 7), Materials.Argon.getGas(2250));
+        RECIPES.put(Pair.of(5, 4), Materials.Helium.getGas(1400000));
+        RECIPES.put(Pair.of(5, 5), Materials.LiquidOxygen.getGas(896000));
+        RECIPES.put(Pair.of(5, 7), Materials.Argon.getGas(8000));
         RECIPES.put(Pair.of(5, 9), Materials.Methane.getGas(1792000));
 
         // T6
         RECIPES.put(Pair.of(6, 1), Materials.Deuterium.getGas(1568000));
         RECIPES.put(Pair.of(6, 2), Materials.Tritium.getGas(240000));
-        RECIPES.put(Pair.of(6, 3), Materials.Ammonia.getGas(2000));
+        RECIPES.put(Pair.of(6, 3), Materials.Ammonia.getGas(240000));
         RECIPES.put(Pair.of(6, 5), Materials.Ethylene.getGas(1792000));
 
         // T7
@@ -68,11 +68,11 @@ public class SpacePumpingRecipes {
 
         if (Loader.isModLoaded("bartworks")) {
             // T5
-            RECIPES.put(Pair.of(5, 6), WerkstoffLoader.Neon.getFluidOrGas(4500));
-            RECIPES.put(Pair.of(5, 8), WerkstoffLoader.Krypton.getFluidOrGas(1000));
+            RECIPES.put(Pair.of(5, 6), WerkstoffLoader.Neon.getFluidOrGas(8000));
+            RECIPES.put(Pair.of(5, 8), WerkstoffLoader.Krypton.getFluidOrGas(32000));
 
             // T6
-            RECIPES.put(Pair.of(6, 4), WerkstoffLoader.Xenon.getFluidOrGas(1750));
+            RECIPES.put(Pair.of(6, 4), WerkstoffLoader.Xenon.getFluidOrGas(16000));
         }
     }
 }


### PR DESCRIPTION
The fluids that are inherited from the siphon are considered lackluster. I talked with glowredman and he agreed that we can buff them for now, but a better siphon implementation will happen in the future, then we can nerf them or remove them here.

- Helium: Half the speed of Helium-3
- Liquid Oxygen: Half the speed of Oxygen
- Ammonia: Ammonia is made from Hydrogen and Nitrogen, with Hydrogen being the dominant factor. If you'd pump hydrogen you'd be able to make 523kL so I used half that value (Since you're saving a pump) and substracted a bit for energy tax.
- Argon, Neon, Krypton, Xenon were just upped a bit. I think they don't need to be that fast.
