### PR TITLE
Ban input hatch and output bus from siphon

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/TileEntityPlanetaryGasSiphon.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/TileEntityPlanetaryGasSiphon.java
@@ -355,7 +355,9 @@ public class TileEntityPlanetaryGasSiphon extends GT_MetaTileEntity_EnhancedMult
         return checkPiece(STRUCTURE_PIECE_MAIN, 1, 6, 0) && mMaintenanceHatches.size() == 1
                 && mInputBusses.size() == 1
                 && mOutputHatches.size() == 1
-                && mEnergyHatches.size() == 1;
+                && mEnergyHatches.size() == 1
+                && mInputHatches.isEmpty()
+                && mOutputBusses.isEmpty();
     }
 
     /**


### PR DESCRIPTION
Both hatches have no function on the siphon and can currently be used to entirely skip crafting advanced machine frames.