### PR TITLE
Prevent maintenance issues from occuring in SE + modules

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
@@ -766,6 +766,14 @@ public class TileEntitySpaceElevator extends GT_MetaTileEntity_EnhancedMultiBloc
     }
 
     /**
+     * @return True as the elevator doesn't have maintenance issues
+     */
+    @Override
+    public boolean doRandomMaintenanceDamage() {
+        return true;
+    }
+
+    /**
      * @return Whether to bind the inventory in the GUI or not
      */
     @Override

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleBase.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleBase.java
@@ -203,6 +203,14 @@ public abstract class TileEntityModuleBase extends GT_MetaTileEntity_EnhancedMul
     }
 
     /**
+     * @return True as modules don't have maintenance issues
+     */
+    @Override
+    public boolean doRandomMaintenanceDamage() {
+        return true;
+    }
+
+    /**
      * Get the maximum EU that this controller can store
      *
      * @return Maximum EU that this controller can store


### PR DESCRIPTION
To fix an edge case, where a maintenance issue can occur and a recipe check will be started, before it would get auto fixed. Instead maintenance issues are now blocked from spawning to begin with.