### PR TITLE
Update TecTech

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1697697256
+//version: 1699290261
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -646,7 +646,7 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.7.1"
+def mixinProviderVersion = "0.1.13"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
 ext.mixinProviderSpec = mixinProviderSpec
@@ -1187,9 +1187,8 @@ publishing {
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
         }
     }
-
     repositories {
-        if (usesMavenPublishing.toBoolean()) {
+        if (usesMavenPublishing.toBoolean() && System.getenv("MAVEN_USER") != null) {
             maven {
                 url = mavenPublishUrl
                 allowInsecureProtocol = mavenPublishUrl.startsWith("http://") // Mostly for the GTNH maven

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.73:dev')
+    api('com.github.GTNewHorizons:TecTech:5.3.13:dev')
     api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.2.11-GTNH:dev')
     api('com.github.GTNewHorizons:GoodGenerator:0.7.5:dev')
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.3.22:dev") {transitive = false}


### PR DESCRIPTION
Timeline:
- Oct 15: Signature of `trySetParameters` got changed, causing incompatibility with Intergalactic (5.3.9) https://github.com/GTNewHorizons/TecTech/pull/246
- Oct 20: Dependency on TecTech in BartWorks got updated to 5.3.9 but never changed since then (0.8.9) https://github.com/GTNewHorizons/bartworks/commit/d8f761d0a6bce74b3f46135085e67b906f6cc359
- (Cascading dep updates, leading Intergalactic to compile with TecTech 5.3.9
- Oct 21: The change got reverted (5.3.10) https://github.com/GTNewHorizons/TecTech/pull/250

I think this is an example of how bad the idea of "keep everything up-to-date" is; Updating dep only when necessary wouldn't have caused this issue. @Dream-Master 

Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14737