### PR TITLE
Avoid a bazillion verts all at once

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId = MODID
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName = MODNAME
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName = GROUPNAME
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = GROUPNAME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
 }
 
 

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/render/RenderSpaceElevatorCable.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/render/RenderSpaceElevatorCable.java
@@ -140,10 +140,8 @@ public class RenderSpaceElevatorCable extends TileEntitySpecialRenderer implemen
         GL11.glDepthMask(true);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         // Draw the cable
-        tessellator.startDrawingQuads();
         tessellator.setColorOpaque_F(1F, 1F, 1F);
         renderFullHelix(tessellator, x, y, z);
-        tessellator.draw();
         // Reset open GL
         GL11.glDisable(GL11.GL_BLEND);
         OpenGlHelper.glBlendFunc(770, 771, 1, 0);
@@ -318,7 +316,7 @@ public class RenderSpaceElevatorCable extends TileEntitySpecialRenderer implemen
 
         double sectionHeight = 8 * side;
         int sections = (int) Math.ceil(CABLE_HEIGHT / sectionHeight);
-
+        // spotless:off
         for (int i = 0; i < 8 * sections; i++) {
             int j = (i + offset) % 8;
             int k = (i + 1 + offset) % 8;
@@ -331,33 +329,13 @@ public class RenderSpaceElevatorCable extends TileEntitySpecialRenderer implemen
                 double lightMinV = cableLight.getMinV();
                 double lightMaxV = cableLight.getMaxV();
 
-                tes.addVertexWithUV(
-                        x + 0.5f + edgeX[k],
-                        y + side * i + side,
-                        z + 0.5f + edgeZ[k],
-                        lightMinU,
-                        lightMaxV);
-                tes.addVertexWithUV(
-                        x + 0.5f + edgeX[k],
-                        y + side * i + (side + width),
-                        z + 0.5f + edgeZ[k],
-                        lightMinU,
-                        lightMinV);
-                tes.addVertexWithUV(
-                        x + 0.5f + edgeX[j],
-                        y + side * i + width,
-                        z + 0.5f + edgeZ[j],
-                        lightMaxU,
-                        lightMinV);
+                tes.addVertexWithUV(x + 0.5f + edgeX[k], y + side * i + side, z + 0.5f + edgeZ[k], lightMinU, lightMaxV);
+                tes.addVertexWithUV(x + 0.5f + edgeX[k], y + side * i + (side + width), z + 0.5f + edgeZ[k], lightMinU, lightMinV);
+                tes.addVertexWithUV(x + 0.5f + edgeX[j], y + side * i + width, z + 0.5f + edgeZ[j], lightMaxU, lightMinV);
                 tes.addVertexWithUV(x + 0.5f + edgeX[j], y + side * i, z + 0.5f + edgeZ[j], lightMaxU, lightMaxV);
             } else {
                 tes.addVertexWithUV(x + 0.5f + edgeX[k], y + side * i + side, z + 0.5f + edgeZ[k], minU, maxV);
-                tes.addVertexWithUV(
-                        x + 0.5f + edgeX[k],
-                        y + side * i + (side + width),
-                        z + 0.5f + edgeZ[k],
-                        minU,
-                        minV);
+                tes.addVertexWithUV(x + 0.5f + edgeX[k], y + side * i + (side + width), z + 0.5f + edgeZ[k], minU, minV);
                 tes.addVertexWithUV(x + 0.5f + edgeX[j], y + side * i + width, z + 0.5f + edgeZ[j], maxU, minV);
                 tes.addVertexWithUV(x + 0.5f + edgeX[j], y + side * i, z + 0.5f + edgeZ[j], maxU, maxV);
             }
@@ -368,6 +346,7 @@ public class RenderSpaceElevatorCable extends TileEntitySpecialRenderer implemen
             tes.addVertexWithUV(x + 0.5f + edgeX[k], y + side * i + (side + width), z + 0.5f + edgeZ[k], minU, minV);
             tes.addVertexWithUV(x + 0.5f + edgeX[k], y + side * i + side, z + 0.5f + edgeZ[k], minU, maxV);
         }
+        // spotless:on
     }
 
     /**
@@ -392,12 +371,22 @@ public class RenderSpaceElevatorCable extends TileEntitySpecialRenderer implemen
         double motorGlowMinV = motorGlow.getMinV();
         double motorGlowMaxV = motorGlow.getMaxV();
 
+        tes.startDrawingQuads();
         clockwiseHelixPart(tes, x, y - 23.0, z, 0, 2.0 / 5.4, 0.75, minU, maxU, minV, maxV);
+        tes.draw();
+        tes.startDrawingQuads();
         clockwiseHelixPart(tes, x, y - 23.0, z, 2, 2.0 / 5.4, 0.75, minU, maxU, minV, maxV);
+        tes.draw();
+        tes.startDrawingQuads();
         clockwiseHelixPart(tes, x, y - 23.0, z, 4, 2.0 / 5.4, 0.75, minU, maxU, minV, maxV);
+        tes.draw();
+        tes.startDrawingQuads();
         clockwiseHelixPart(tes, x, y - 23.0, z, 6, 2.0 / 5.4, 0.75, minU, maxU, minV, maxV);
+        tes.draw();
 
+        tes.startDrawingQuads();
         motorGlow(tes, x, y, z, motorGlowMinU, motorGlowMaxU, motorGlowMinV, motorGlowMaxV);
+        tes.draw();
     }
 
     /**


### PR DESCRIPTION
First of many optimizations to come.  Takes 4 space elevators from ~300gb of allocations from tessellator buffer expansion to _significantly_ less.