### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/GTNHIntergalactic.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/GTNHIntergalactic.java
@@ -29,7 +29,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
                 + "required-after:gtnhlib@[0.0.8.1,);"
                 + "required-after:tectech;"
                 + "required-after:structurelib;"
-                + "required-after:galaxyspace;"
+                + "required-after:GalaxySpace;"
                 + "after:bartworks;"
                 + "after:GoodGenerator;"
                 + "after:miscutils;"

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -12,10 +12,6 @@
 		"credits": "",
 		"logoFile": "assets/gtnhintergalactic/textures/gui/picture/space_elevator_logo.png",
 		"screenshots": [],
-		"parent": "",
-		"requiredMods": [],
-		"dependencies": ["GT5-Unofficial", "TecTech", "ModularUI", "GalaxySpace", "GalactiCraft"],
-		"dependants": [],
-		"useDependencyInformation": true
+		"parent": ""
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.