### PR TITLE
Add amethyst ore to space mining

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/SpaceMiningRecipes.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/SpaceMiningRecipes.java
@@ -223,10 +223,10 @@ public class SpaceMiningRecipes {
         addRecipesToDrones(
                 null,
                 null,
-                new int[] { 1500, 1500, 1500, 1500, 750, 750, 1000, 500, 500, 400, 100 },
+                new int[] { 1500, 1500, 1500, 1500, 750, 750, 750, 1000, 500, 500, 400, 100 },
                 new Materials[] { Materials.Ruby, Materials.Emerald, Materials.Sapphire, Materials.GreenSapphire,
-                        Materials.Diamond, Materials.Opal, Materials.Topaz, Materials.BlueTopaz, Materials.Bauxite,
-                        Materials.Vinteum, Materials.NetherStar },
+                        Materials.Diamond, Materials.Opal, Materials.Amethyst, Materials.Topaz, Materials.BlueTopaz,
+                        Materials.Bauxite, Materials.Vinteum, Materials.NetherStar },
                 OrePrefixes.oreEndstone,
                 30,
                 160,


### PR DESCRIPTION
Adds amethyst ore to the gem asteroid, as amethyst is needed for prasiolite, which in turn is used in magneto resonatic dust and circuit imprints.

![image](https://github.com/user-attachments/assets/03aa8785-9239-4c65-945e-e04c02dd4d4f)
