### PR TITLE
add MTE IDs to the GT enum

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.45:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.44:dev')
     api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.91-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.4.9:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.4.8:dev')
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.52:dev") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.44:dev')
-    api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.90-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.4.8:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.45:dev')
+    api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.91-GTNH:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.4.9:dev')
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.52:dev") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.44:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.45:dev')
     api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.91-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.4.8:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.4.9:dev')
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.52:dev") {transitive = false}
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.38:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.44:dev')
     api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.90-GTNH:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.4.8:dev')
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.52:dev") {transitive = false}

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/loader/MachineLoader.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/loader/MachineLoader.java
@@ -1,5 +1,19 @@
 package com.gtnewhorizons.gtnhintergalactic.loader;
 
+import static gregtech.api.enums.MetaTileEntityIDs.PlanetaryGasSiphonController;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorController;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT1;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT2;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT3;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleManager;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT1;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT2;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT3;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT1;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT2;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT3;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleResearch;
+
 import com.gtnewhorizons.gtnhintergalactic.item.IGItems;
 import com.gtnewhorizons.gtnhintergalactic.tile.multi.TileEntityPlanetaryGasSiphon;
 import com.gtnewhorizons.gtnhintergalactic.tile.multi.elevator.TileEntitySpaceElevator;
@@ -11,20 +25,6 @@ import com.gtnewhorizons.gtnhintergalactic.tile.multi.elevatormodules.TileEntity
 
 import gregtech.api.enums.ItemList;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
-
-import static gregtech.api.enums.MetaTileEntityIDs.PlanetaryGasSiphonController;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT1;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT2;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT3;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorController;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT1;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT2;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT3;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleManager;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT1;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT2;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT3;
-import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleResearch;
 
 /**
  * Loader for all machines
@@ -64,15 +64,15 @@ public class MachineLoader implements Runnable {
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.name")).getStackForm(1);
 
         IGItems.SpaceElevatorModuleMinerT1 = new TileEntityModuleMiner.TileEntityModuleMinerT1(
-            SpaceElevatorModuleMinerT1.ID,
+                SpaceElevatorModuleMinerT1.ID,
                 "ProjectModuleMinerT1",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t1.name")).getStackForm(1);
         IGItems.SpaceElevatorModuleMinerT2 = new TileEntityModuleMiner.TileEntityModuleMinerT2(
-            SpaceElevatorModuleMinerT2.ID,
+                SpaceElevatorModuleMinerT2.ID,
                 "ProjectModuleMinerT2",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t2.name")).getStackForm(1);
         IGItems.SpaceElevatorModuleMinerT3 = new TileEntityModuleMiner.TileEntityModuleMinerT3(
-            SpaceElevatorModuleMinerT3.ID,
+                SpaceElevatorModuleMinerT3.ID,
                 "ProjectModuleMinerT3",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t3.name")).getStackForm(1);
 

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/loader/MachineLoader.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/loader/MachineLoader.java
@@ -9,7 +9,22 @@ import com.gtnewhorizons.gtnhintergalactic.tile.multi.elevatormodules.TileEntity
 import com.gtnewhorizons.gtnhintergalactic.tile.multi.elevatormodules.TileEntityModulePump;
 import com.gtnewhorizons.gtnhintergalactic.tile.multi.elevatormodules.TileEntityModuleResearch;
 
+import gregtech.api.enums.ItemList;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
+
+import static gregtech.api.enums.MetaTileEntityIDs.PlanetaryGasSiphonController;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT1;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT2;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleMinerT3;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorController;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT1;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT2;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleAssemblerT3;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleManager;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT1;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT2;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModulePumpT3;
+import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleResearch;
 
 /**
  * Loader for all machines
@@ -25,61 +40,62 @@ public class MachineLoader implements Runnable {
     public void run() {
 
         IGItems.PlanetaryGasSiphon = new TileEntityPlanetaryGasSiphon(
-                14002,
+                PlanetaryGasSiphonController.ID,
                 "PlanetaryGasSiphon",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.name")).getStackForm(1);
 
         IGItems.SpaceElevatorController = new TileEntitySpaceElevator(
-                14003,
+                SpaceElevatorController.ID,
                 "SpaceElevator",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.name")).getStackForm(1);
+        ItemList.SpaceElevatorController.set(IGItems.SpaceElevatorController);
 
         IGItems.SpaceElevatorModuleAssemblerT1 = new TileEntityModuleAssembler.TileEntityModuleAssemblerT1(
-                14004,
+                SpaceElevatorModuleAssemblerT1.ID,
                 "ProjectModuleAssemblerT1",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.name")).getStackForm(1);
         IGItems.SpaceElevatorModuleAssemblerT2 = new TileEntityModuleAssembler.TileEntityModuleAssemblerT2(
-                14005,
+                SpaceElevatorModuleAssemblerT2.ID,
                 "ProjectModuleAssemblerT2",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.name")).getStackForm(1);
         IGItems.SpaceElevatorModuleAssemblerT3 = new TileEntityModuleAssembler.TileEntityModuleAssemblerT3(
-                14006,
+                SpaceElevatorModuleAssemblerT3.ID,
                 "ProjectModuleAssemblerT3",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.name")).getStackForm(1);
 
         IGItems.SpaceElevatorModuleMinerT1 = new TileEntityModuleMiner.TileEntityModuleMinerT1(
-                14007,
+            SpaceElevatorModuleMinerT1.ID,
                 "ProjectModuleMinerT1",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t1.name")).getStackForm(1);
         IGItems.SpaceElevatorModuleMinerT2 = new TileEntityModuleMiner.TileEntityModuleMinerT2(
-                14008,
+            SpaceElevatorModuleMinerT2.ID,
                 "ProjectModuleMinerT2",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t2.name")).getStackForm(1);
         IGItems.SpaceElevatorModuleMinerT3 = new TileEntityModuleMiner.TileEntityModuleMinerT3(
-                14009,
+            SpaceElevatorModuleMinerT3.ID,
                 "ProjectModuleMinerT3",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t3.name")).getStackForm(1);
 
         IGItems.SpaceElevatorModulePumpT1 = new TileEntityModulePump.TileEntityModulePumpT1(
-                14010,
+                SpaceElevatorModulePumpT1.ID,
                 "ProjectModulePumpT1",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.name")).getStackForm(1);
         IGItems.SpaceElevatorModulePumpT2 = new TileEntityModulePump.TileEntityModulePumpT2(
-                14011,
+                SpaceElevatorModulePumpT2.ID,
                 "ProjectModulePumpT2",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.name")).getStackForm(1);
         IGItems.SpaceElevatorModulePumpT3 = new TileEntityModulePump.TileEntityModulePumpT3(
-                14014,
+                SpaceElevatorModulePumpT3.ID,
                 "ProjectModulePumpT3",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t3.name")).getStackForm(1);
 
         IGItems.SpaceElevatorModuleManager = new TileEntityModuleManager(
-                14012,
+                SpaceElevatorModuleManager.ID,
                 "ProjectModuleManager",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.manager.t1.name")).getStackForm(1);
 
         IGItems.SpaceElevatorModuleResearch = new TileEntityModuleResearch(
-                14013,
+                SpaceElevatorModuleResearch.ID,
                 "ProjectModuleResearch",
                 GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.research.t1.name")).getStackForm(1);
     }

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/MachineRecipes.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/MachineRecipes.java
@@ -50,49 +50,24 @@ public class MachineRecipes implements Runnable {
     @Override
     public void run() {
 
-        ItemStack hypogenFrameBox_8, hypogenScrew_32, preciseAssembler_1, highComputationStationT3_32,
-                highComputationStationT4_32, highComputationStationT5_32, metaStableOgScrew_64, shirabonGear_8,
-                shirabonGearSmall_16, titaniumBetaCScrew_64, voidMiner;
-        Fluid hypogenFluid, celestialTungstenFluid;
+        // exit early if not in pack
+        if (!Loader.isModLoaded("dreamcraft")) return;
 
-        if (Loader.isModLoaded("miscutils")) {
-            hypogenFrameBox_8 = ELEMENT.STANDALONE.HYPOGEN.getFrameBox(8);
-            hypogenScrew_32 = ELEMENT.STANDALONE.HYPOGEN.getScrew(32);
-            hypogenFluid = ELEMENT.STANDALONE.HYPOGEN.getFluid();
-            celestialTungstenFluid = ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluid();
-        } else {
-            hypogenFrameBox_8 = GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Infinity, 8);
-            hypogenScrew_32 = GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Infinity, 32);
-            hypogenFluid = Materials.Infinity.getFluid(0).getFluid();
-            celestialTungstenFluid = MaterialsUEVplus.SpaceTime.getFluid(0).getFluid();
-        }
+        ItemStack hypogenFrameBox_8 = ELEMENT.STANDALONE.HYPOGEN.getFrameBox(8);
+        ItemStack hypogenScrew_32 = ELEMENT.STANDALONE.HYPOGEN.getScrew(32);
+        Fluid hypogenFluid = ELEMENT.STANDALONE.HYPOGEN.getFluid();
+        Fluid celestialTungstenFluid = ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluid();
 
-        if (Loader.isModLoaded("GoodGenerator")) {
-            preciseAssembler_1 = ItemRefer.Precise_Assembler.get(1);
-            highComputationStationT3_32 = ItemRefer.HiC_T3.get(32);
-            highComputationStationT4_32 = ItemRefer.HiC_T4.get(32);
-            highComputationStationT5_32 = ItemRefer.HiC_T5.get(32);
-            metaStableOgScrew_64 = MyMaterial.metastableOganesson.get(OrePrefixes.screw, 64);
-            shirabonGear_8 = MyMaterial.shirabon.get(OrePrefixes.gearGt, 8);
-            shirabonGearSmall_16 = MyMaterial.shirabon.get(OrePrefixes.gearGtSmall, 16);
-            titaniumBetaCScrew_64 = MyMaterial.titaniumBetaC.get(OrePrefixes.screw, 64);
-        } else {
-            preciseAssembler_1 = ItemList.Machine_IV_Assembler.get(1);
-            highComputationStationT3_32 = GT_OreDictUnificator
-                    .get(OrePrefixes.circuit, Materials.SuperconductorUHV, 32);
-            highComputationStationT4_32 = GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinite, 32);
-            highComputationStationT5_32 = GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Bio, 32);
-            metaStableOgScrew_64 = GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Neutronium, 64);
-            shirabonGear_8 = GT_OreDictUnificator.get(OrePrefixes.gearGt, Materials.Infinity, 8);
-            shirabonGearSmall_16 = GT_OreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Infinity, 16);
-            titaniumBetaCScrew_64 = GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Osmiridium, 64);
-        }
+        ItemStack preciseAssembler_1 = ItemRefer.Precise_Assembler.get(1);
+        ItemStack highComputationStationT3_32 = ItemRefer.HiC_T3.get(32);
+        ItemStack highComputationStationT4_32 = ItemRefer.HiC_T4.get(32);
+        ItemStack highComputationStationT5_32 = ItemRefer.HiC_T5.get(32);
+        ItemStack metaStableOgScrew_64 = MyMaterial.metastableOganesson.get(OrePrefixes.screw, 64);
+        ItemStack shirabonGear_8 = MyMaterial.shirabon.get(OrePrefixes.gearGt, 8);
+        ItemStack shirabonGearSmall_16 = MyMaterial.shirabon.get(OrePrefixes.gearGtSmall, 16);
+        ItemStack titaniumBetaCScrew_64 = MyMaterial.titaniumBetaC.get(OrePrefixes.screw, 64);
 
-        if (Loader.isModLoaded("bartworks")) {
-            voidMiner = ItemRegistry.voidminer[2];
-        } else {
-            voidMiner = ItemList.OreDrill4.get(1);
-        }
+        ItemStack voidMiner = ItemRegistry.voidminer[2];
 
         // Planetary Gas Siphon Controller
         RecipeUtil.addRecipe(

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/ResultNoSpaceProject.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/ResultNoSpaceProject.java
@@ -1,7 +1,10 @@
 package com.gtnewhorizons.gtnhintergalactic.recipe;
 
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.StatCollector;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
 
@@ -58,6 +61,19 @@ public class ResultNoSpaceProject implements CheckRecipeResult {
                 "GT5U.gui.text.missing_project",
                 StatCollector.translateToLocal(neededProject),
                 StatCollector.translateToLocal(neededLocation));
+    }
+
+    @Override
+    public @NotNull NBTTagCompound writeToNBT(@NotNull NBTTagCompound tag) {
+        tag.setString("neededProject", neededProject);
+        tag.setString("neededLocation", neededLocation);
+        return tag;
+    }
+
+    @Override
+    public void readFromNBT(@NotNull NBTTagCompound tag) {
+        neededProject = tag.getString("needProject");
+        neededLocation = tag.getString("neededLocation");
     }
 
     /**


### PR DESCRIPTION
Also made it so the space elevator controller is now in the GT5U ItemList, so it does solve the issue where GT5U requires GTNH-I to make the EoH recipe.