### PR TITLE
Improve space elevator module tooltips

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.94:dev')
-    api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.93-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.5.8:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.111:dev')
+    api('com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.94-GTNH:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.62:dev") {transitive = false}
 }

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModulePump.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModulePump.java
@@ -403,20 +403,15 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
             tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0")) // Module that
-                    // adds Space
-                    // Pumping
-                    // Operations to the
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
                     .addInfo(
                             EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                                    + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc1")) // Sucking
-                    // up
-                    // entire
-                    // gas planets was
-                    // never easier
+                                    + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc1"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
+
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc5"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT2")).addSeparator()
                     .beginStructureBlock(1, 5, 2, false)
                     .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
@@ -500,20 +495,18 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
             tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0")) // Module that
-                    // adds Space
-                    // Pumping
-                    // Operations to the
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
                     .addInfo(
                             EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                                    + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc1")) // Literally
-                    // sucks
+                                    + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc1"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
-                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
+
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc5"))
-                    .addSeparator().beginStructureBlock(1, 5, 2, false)
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc6"))
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT3")).addSeparator()
+                    .beginStructureBlock(1, 5, 2, false)
                     .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
                     .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                     .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
@@ -601,10 +594,12 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
                                     + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t3.desc1"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
-                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT4"))
+
                     .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
-                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc5"))
-                    .addSeparator().beginStructureBlock(1, 5, 2, false)
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t3.desc5"))
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc6"))
+                    .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT4")).addSeparator()
+                    .beginStructureBlock(1, 5, 2, false)
                     .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
                     .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                     .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)

--- a/src/main/resources/assets/gtnhintergalactic/lang/en_US.lang
+++ b/src/main/resources/assets/gtnhintergalactic/lang/en_US.lang
@@ -192,9 +192,9 @@ gt.blockmachines.multimachine.project.ig.assembler.desc0=Module that adds the Sp
 gt.blockmachines.multimachine.project.ig.assembler.t1.desc1=Why do I need to assemble stuff in space again?
 gt.blockmachines.multimachine.project.ig.assembler.t2.desc1=Is this really necessary?
 gt.blockmachines.multimachine.project.ig.assembler.t3.desc1=I guess we'll never know.
-gt.blockmachines.multimachine.project.ig.assembler.t1.desc2=Up to 4 parallels
-gt.blockmachines.multimachine.project.ig.assembler.t2.desc2=Up to 16 parallels
-gt.blockmachines.multimachine.project.ig.assembler.t3.desc2=Up to 64 parallels
+gt.blockmachines.multimachine.project.ig.assembler.t1.desc2=Runs at UHV with up to 4 parallels
+gt.blockmachines.multimachine.project.ig.assembler.t2.desc2=Runs at UIV with up to 16 parallels
+gt.blockmachines.multimachine.project.ig.assembler.t3.desc2=Runs at UXV with up to 64 parallels
 gt.blockmachines.multimachine.project.ig.assembler.cfgi.0=Max parallels
 
 # Module Miner
@@ -216,9 +216,9 @@ gt.blockmachines.multimachine.project.ig.miner.t2.desc1=Does this violate drone 
 gt.blockmachines.multimachine.project.ig.miner.t3.desc1=This definitely violates drone rights.
 gt.blockmachines.multimachine.project.ig.miner.desc3=Requires a plasma to operate (1000L Helium / 500L Bismuth / 300L Radon).
 gt.blockmachines.multimachine.project.ig.miner.desc4=Higher tier plasmas give bonuses.
-gt.blockmachines.multimachine.project.ig.miner.t1.desc5=Up to 2 parallels
-gt.blockmachines.multimachine.project.ig.miner.t2.desc5=Up to 4 parallels
-gt.blockmachines.multimachine.project.ig.miner.t3.desc5=Up to 8 parallels
+gt.blockmachines.multimachine.project.ig.miner.t1.desc5=Runs at UV with up to 2 parallels
+gt.blockmachines.multimachine.project.ig.miner.t2.desc5=Runs at UHV with up to 4 parallels
+gt.blockmachines.multimachine.project.ig.miner.t3.desc5=Runs at UEV with up to 8 parallels
 gt.blockmachines.multimachine.project.ig.miner.desc6=Ores can be black-/whitelisted by putting them in an input bus
 
 # Module Pump
@@ -231,7 +231,10 @@ gt.blockmachines.multimachine.project.ig.pump.t2.desc1=Literally sucks
 gt.blockmachines.multimachine.project.ig.pump.t3.desc1=S U C C
 gt.blockmachines.multimachine.project.ig.pump.desc3=Set Planet and Gas Type determine pumped fluid
 gt.blockmachines.multimachine.project.ig.pump.desc4=Can be void protected by locking output hatches
-gt.blockmachines.multimachine.project.ig.pump.t2.desc5=Processes up to 4 different recipes at once
+gt.blockmachines.multimachine.project.ig.pump.t1.desc5=Runs at UHV with up to 4 parallels
+gt.blockmachines.multimachine.project.ig.pump.t2.desc5=Runs at UEV with up to 4 parallels per recipe
+gt.blockmachines.multimachine.project.ig.pump.t3.desc5=Runs at UXV with up to 64 parallels per recipe
+gt.blockmachines.multimachine.project.ig.pump.t2.desc6=Processes up to 4 different recipes at once
 gt.blockmachines.multimachine.project.ig.pump.cfgi.0=Planet Type
 gt.blockmachines.multimachine.project.ig.pump.cfgi.1=Gas Type
 gt.blockmachines.multimachine.project.ig.pump.cfgi.2=Parallels


### PR DESCRIPTION
- Specify the voltage that each module runs at in the tooltip
- Clarify that space pump T2+3 parallels are per recipe, rather than total
- Improve the ordering on space pump tooltip to keep minimum motor tier tooltip at the bottom like other modules