### PR TITLE
Add tier check to space assembler

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
@@ -139,7 +139,7 @@ public abstract class TileEntityModuleAssembler extends TileEntityModuleBase imp
                     }
                 }
 
-                if (getTier() < recipe.mSpecialValue) {
+                if (tModuleTier < recipe.mSpecialValue) {
                     return CheckRecipeResultRegistry.insufficientMachineTier(recipe.mSpecialValue);
                 }
 

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
@@ -138,6 +138,11 @@ public abstract class TileEntityModuleAssembler extends TileEntityModuleBase imp
                         return new ResultNoSpaceProject(neededProject, neededLocation);
                     }
                 }
+
+                if (getTier() < recipe.mSpecialValue) {
+                    return CheckRecipeResultRegistry.insufficientMachineTier(recipe.mSpecialValue);
+                }
+
                 return CheckRecipeResultRegistry.SUCCESSFUL;
             }
         }.setAmperageOC(false).setMaxParallelSupplier(() -> Math.min(getMaxParallels(), (int) parallelSetting.get()));


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18737

Previously this always relied on the EU/t check making a recipe fail. However that doesn't work in all cases, especially MK3 recipes