### PR TITLE
Fix dyson casings not using proper meta methods

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/block/BlockCasingDysonSwarm.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/block/BlockCasingDysonSwarm.java
@@ -7,7 +7,6 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -76,10 +75,5 @@ public class BlockCasingDysonSwarm extends Block {
     @Override
     public int damageDropped(int meta) {
         return meta;
-    }
-
-    @Override
-    public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-        world.setBlockMetadataWithNotify(x, y, z, stack.getItemDamage(), 3);
     }
 }

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/item/ItemCasingDysonSwarm.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/item/ItemCasingDysonSwarm.java
@@ -29,4 +29,9 @@ public class ItemCasingDysonSwarm extends ItemBlock {
             tooltip.add("Blast Resistance: 1500");
         }
     }
+
+    @Override
+    public int getMetadata(int meta) {
+        return meta;
+    }
 }


### PR DESCRIPTION
Dyson blocks were manually setting their meta when they were placed. A mechanism exists in ItemBlock for this, so the hack was replaced with it. This lets the matter manipulator break the block without custom code for it.

Fixes: https://github.com/RecursivePineapple/MatterManipulator/issues/26
