### PR TITLE
Merge itemstacks in some assline recipes 3/3

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/MachineRecipes.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/MachineRecipes.java
@@ -81,7 +81,8 @@ public class MachineRecipes implements Runnable {
                 4,
                 new Object[] { GTModHandler.getModItem("OpenBlocks", "elevator", 1),
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 64),
-                        ItemList.Field_Generator_UV.get(16), new Object[] { OrePrefixes.circuit.get(Materials.UHV), 16 },
+                        ItemList.Field_Generator_UV.get(16),
+                        new Object[] { OrePrefixes.circuit.get(Materials.UHV), 16 },
                         GTModHandler.getModItem("dreamcraft", "item.HeavyDutyPlateTier7", 32),
                         ItemList.Circuit_Chip_PPIC.get(64),
                         GTOreDictUnificator.get(OrePrefixes.screw, Materials.CosmicNeutronium, 64),
@@ -105,13 +106,12 @@ public class MachineRecipes implements Runnable {
 
         // Space Elevator Cable
         RA.stdBuilder()
-            .itemInputs(
-                new ItemStack(IGItems.SpaceElevatorItems, 64, 0),
-                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UHV, 4))
-            .fluidInputs(
-                FluidRegistry.getFluidStack("molten.ethylcyanoacrylatesuperglue", 8000))
-            .itemOutputs(new ItemStack(IGBlocks.SpaceElevatorCable))
-            .duration(2 * MINUTE).eut(TierEU.RECIPE_UHV).addTo(assemblerRecipes);
+                .itemInputs(
+                        new ItemStack(IGItems.SpaceElevatorItems, 64, 0),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UHV, 4))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.ethylcyanoacrylatesuperglue", 8000))
+                .itemOutputs(new ItemStack(IGBlocks.SpaceElevatorCable)).duration(2 * MINUTE).eut(TierEU.RECIPE_UHV)
+                .addTo(assemblerRecipes);
 
         // Space Elevator Base Casing
         TTRecipeAdder.addResearchableAssemblylineRecipe(

--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/MachineRecipes.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/recipe/MachineRecipes.java
@@ -81,10 +81,7 @@ public class MachineRecipes implements Runnable {
                 4,
                 new Object[] { GTModHandler.getModItem("OpenBlocks", "elevator", 1),
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 64),
-                        ItemList.Field_Generator_UV.get(16), new Object[] { OrePrefixes.circuit.get(Materials.UHV), 4 },
-                        new Object[] { OrePrefixes.circuit.get(Materials.UHV), 4 },
-                        new Object[] { OrePrefixes.circuit.get(Materials.UHV), 4 },
-                        new Object[] { OrePrefixes.circuit.get(Materials.UHV), 4 },
+                        ItemList.Field_Generator_UV.get(16), new Object[] { OrePrefixes.circuit.get(Materials.UHV), 16 },
                         GTModHandler.getModItem("dreamcraft", "item.HeavyDutyPlateTier7", 32),
                         ItemList.Circuit_Chip_PPIC.get(64),
                         GTOreDictUnificator.get(OrePrefixes.screw, Materials.CosmicNeutronium, 64),
@@ -107,21 +104,14 @@ public class MachineRecipes implements Runnable {
                 .requiresCleanRoom().addTo(assemblerRecipes);
 
         // Space Elevator Cable
-        TTRecipeAdder.addResearchableAssemblylineRecipe(
-                new ItemStack(IGItems.SpaceElevatorItems, 1, 0),
-                128000,
-                256,
-                (int) TierEU.RECIPE_UV,
-                2,
-                new Object[] { new ItemStack(IGItems.SpaceElevatorItems, 16, 0),
-                        new ItemStack(IGItems.SpaceElevatorItems, 16, 0),
-                        new ItemStack(IGItems.SpaceElevatorItems, 16, 0),
-                        new ItemStack(IGItems.SpaceElevatorItems, 16, 0),
-                        new Object[] { OrePrefixes.circuit.get(Materials.UHV), 4 }, },
-                new FluidStack[] { Materials.AdvancedGlue.getFluid(720) },
-                new ItemStack(IGBlocks.SpaceElevatorCable),
-                1 * MINUTE,
-                (int) TierEU.RECIPE_UHV);
+        RA.stdBuilder()
+            .itemInputs(
+                new ItemStack(IGItems.SpaceElevatorItems, 64, 0),
+                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UHV, 4))
+            .fluidInputs(
+                FluidRegistry.getFluidStack("molten.ethylcyanoacrylatesuperglue", 8000))
+            .itemOutputs(new ItemStack(IGBlocks.SpaceElevatorCable))
+            .duration(2 * MINUTE).eut(TierEU.RECIPE_UHV).addTo(assemblerRecipes);
 
         // Space Elevator Base Casing
         TTRecipeAdder.addResearchableAssemblylineRecipe(


### PR DESCRIPTION
Main PR: [#4008](https://github.com/GTNewHorizons/GT5-Unofficial/pull/4008)
**Moves Space Elevator Cable from assline to assembler and replaces advanced glue with 8000L super glue!**
I don't think this recipe should be in the assembly line. it uses 2 items and a single fluid and you make maybe 16 maximum in the entire run. Forces super glue a bit earlier; can be moved to a different PR
Change discussed with @Nockyx 
![Space_Elevator_Cable_New](https://github.com/user-attachments/assets/065fe264-c78e-4966-b2be-40ec960fd934)

Affected recipes:
**Space Elevator Controller**
![Space_Elevator](https://github.com/user-attachments/assets/f165a062-a74f-48c0-a216-f79b273a97d2)

