### PR TITLE
Add mining drone controller slot

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
+++ b/src/main/java/com/gtnewhorizons/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
@@ -312,6 +312,11 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
     /** Determine which drones and items are in the correct buses */
     protected ItemStack[] validInputs() {
         ArrayList<ItemStack> validatedInputs = new ArrayList<>();
+        // Accept item from controller if it's a drone
+        ItemStack controllerSlot = this.getControllerSlot();
+        if ( controllerSlot != null && controllerSlot.getItem() instanceof ItemMiningDrones ){
+            validatedInputs.add(controllerSlot);
+        }
         Map<GTUtility.ItemId, ItemStack> inputsFromME = new HashMap<>();
         for (MTEHatchInputBus inputBus : validMTEList(mInputBusses)) {
             IGregTechTileEntity tileEntity = inputBus.getBaseMetaTileEntity();


### PR DESCRIPTION
Add the option to put a drone in the controller slot of the space elevator mining modules
![image](https://github.com/user-attachments/assets/2c760527-a0bf-4f75-b77d-8a6b7ac98417)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19203